### PR TITLE
Fixed crash when pressing enter and having multiple cursor

### DIFF
--- a/src/Geno/C++/GUI/Widgets/TextEdit.cpp
+++ b/src/Geno/C++/GUI/Widgets/TextEdit.cpp
@@ -1508,7 +1508,7 @@ void TextEdit::Enter( File& rFile )
 			rLine.erase( Start, rLine.end() );
 		}
 
-		AdjustCursors( rFile, i, rCursor.Position.x, MoveRemainingTextToNewLine ? -1 : 0 );
+		AdjustCursors( rFile, i, rCursor.Position.x, -1 );
 
 		rCursor.Position.y++;
 		rCursor.Position.x = 0;


### PR DESCRIPTION
Fixed crash when the main cursor was on a lower line number and at the end of the line.