### PR TITLE
Fixed crash when opening directory

### DIFF
--- a/src/Geno/C++/GUI/Modals/OpenFileModal.cpp
+++ b/src/Geno/C++/GUI/Modals/OpenFileModal.cpp
@@ -274,7 +274,7 @@ void OpenFileModal::UpdateDerived( void )
 					ImGui::TableSetupColumn( "Size", ImGuiTableColumnFlags_WidthFixed, ImGui::CalcTextSize( "Size" ).x * 2.5f );
 					ImGui::TableHeadersRow();
 
-					for( const auto& rCurrentPathIt : std::filesystem::directory_iterator( m_CurrentPath ) )
+					for( const auto& rCurrentPathIt : std::filesystem::directory_iterator( m_CurrentPath , std::filesystem::directory_options::skip_permission_denied ) )
 					{
 						std::filesystem::path Path         = rCurrentPathIt.path();
 						bool                  IsHiddenFile = Path.filename().string()[ 0 ] == '.';


### PR DESCRIPTION
Partly fixes #42. Fixes the crash that happens when you open a directory that you don't have permissions to open.